### PR TITLE
Added dockerhub publish to github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         run: docker login docker.pkg.github.com -u ${{ secrets.PACKAGE_USERNAME }} -p ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        run: docker login hub.docker.com -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+        run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build container image
         run: docker build -t docker.pkg.github.com/foundato/kelon/kelon:$(git rev-parse --short HEAD) -t kelonio/kelon:$(git rev-parse --short HEAD) -t kelonio/kelon:latest .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,8 +71,14 @@ jobs:
       - name: Login to Registry
         run: docker login docker.pkg.github.com -u ${{ secrets.PACKAGE_USERNAME }} -p ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to DockerHub
+        run: docker login hub.docker.com -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build container image
-        run: docker build -t docker.pkg.github.com/foundato/kelon/kelon:$(git rev-parse --short HEAD) .
+        run: docker build -t docker.pkg.github.com/foundato/kelon/kelon:$(git rev-parse --short HEAD) -t kelonio/kelon:$(git rev-parse --short HEAD) -t kelonio/kelon:latest .
 
       - name: Push image to github packages
         run: docker push docker.pkg.github.com/foundato/kelon/kelon:$(git rev-parse --short HEAD)
+
+      - name: Push images to DockerHub
+        run: echo kelonio/kelon:$(git rev-parse --short HEAD) kelonio/kelon:latest | xargs -n 1 docker push


### PR DESCRIPTION
Allows pushing the latest tag and a tag containing the commit id to docker hub and so into our public repo.