### PR TITLE
Added parsing of connection options for datastores

### DIFF
--- a/examples/docker-compose/config/datastore.yml
+++ b/examples/docker-compose/config/datastore.yml
@@ -17,6 +17,7 @@ datastores:
       database: appstore
       user: You
       password: SuperSecure
+      sslmode: disable
 
   mongo:
     type: mongo

--- a/examples/local/config/datastore.yml
+++ b/examples/local/config/datastore.yml
@@ -17,6 +17,7 @@ datastores:
       database: appstore
       user: You
       password: SuperSecure
+      sslmode: disable
 
   mongo:
     type: mongo


### PR DESCRIPTION
Connection-Options for each datastore can now be added as key-value-pair to the connection itself.
Please see the kelon-docs (branch:develop) (Page: Operations /operations/Configuration/#connection-options) for more details

![image](https://user-images.githubusercontent.com/53233799/71572769-09e17480-2ae1-11ea-8fe9-76ce32be39e4.png)


![image](https://user-images.githubusercontent.com/53233799/71572754-f3d3b400-2ae0-11ea-90f5-735239076f5a.png)
