### PR TITLE
Fixed error in link logic

### DIFF
--- a/examples/local/policies/mongo_example.rego
+++ b/examples/local/policies/mongo_example.rego
@@ -14,15 +14,11 @@ allow = true {
     data.mongo.apps[app].id == appId
 
     # Nest elements
-    data.mongo.rights[right].id == app.id
-    data.mongo.users[user].id == right.id
+    data.mongo.rights[right].right == "OWNER"
+    data.mongo.users[user].name == input.user
 
     # Query root
     app.stars > 2
-
-    # Query nested
-    right.right == "OWNER"
-    user.name == input.user
 }
 
 # Path: GET /api/mongo/apps/:app_id

--- a/internal/pkg/data/mongo-datastore.go
+++ b/internal/pkg/data/mongo-datastore.go
@@ -9,18 +9,15 @@ import (
 	"sync"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson"
-
-	"go.mongodb.org/mongo-driver/mongo/readpref"
-
 	"github.com/Foundato/kelon/configs"
 	"github.com/Foundato/kelon/internal/pkg/util"
 	"github.com/Foundato/kelon/pkg/data"
-
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
 type mongoDatastore struct {
@@ -250,9 +247,8 @@ func (ds mongoDatastore) translate(input *data.Node) map[string]string {
 			})
 			relations = relations[:0]
 		case data.Link:
-			// Reset entities and relations because mongo does not join, but can only access directly nested elements!
+			// Reset entities because mongo does not join, but can only access directly nested elements!
 			entities = entities[:0]
-			relations = relations[:0]
 		case data.Condition:
 			// Skip condition
 		case data.Conjunction:

--- a/internal/pkg/data/sql-datastore.go
+++ b/internal/pkg/data/sql-datastore.go
@@ -171,15 +171,11 @@ func (ds sqlDatastore) translate(input *data.Node) string {
 			joins = joins[:0]
 			relations = relations[:0]
 		case data.Link:
-			// Expected stack: entities-top -> [entities] relations-top -> [relations]
-			if len(entities) != len(relations) {
-				log.Errorf("Error while creating Link: Entities and relations are not balanced! Lengths are Entities[%d:%d]Relations", len(entities), len(relations))
-			}
-			for i, entity := range entities {
-				joins = joins.Push(fmt.Sprintf(" INNER JOIN %s ON %s", entity, strings.Replace(relations[i], "WHERE", "", 1)))
+			// Expected stack: entities-top -> [entities]
+			for _, entity := range entities {
+				joins = joins.Push(fmt.Sprintf(", %s", entity))
 			}
 			entities = entities[:0]
-			relations = relations[:0]
 		case data.Condition:
 			// Expected stack: relations-top -> [singleRelation]
 			if len(relations) > 0 {

--- a/internal/pkg/translate/default-preprocessor.go
+++ b/internal/pkg/translate/default-preprocessor.go
@@ -87,7 +87,7 @@ func (processor *astPreprocessor) transformRefs(value interface{}) (interface{},
 		// Keep track of iterators used for each table. We do not support
 		// self-links currently. Self-links require namespacing in the SQL
 		// value.
-		if _, ok := processor.tableNames[tableName]; ok {
+		if match, ok := processor.tableNames[tableName]; ok && match != rowID.String() {
 			return nil, errors.New("invalid reference: self-links not supported")
 		}
 		processor.tableNames[tableName] = rowID.String()

--- a/pkg/data/ast.go
+++ b/pkg/data/ast.go
@@ -25,10 +25,8 @@ type Query struct {
 }
 
 // Link between a parent entity and a list of entities with corresponding conditions.
-// Note that len(Entities) == len(conditions)
 type Link struct {
-	Entities   []Entity
-	Conditions []Node
+	Entities []Entity
 }
 
 // A single root condition.
@@ -187,16 +185,13 @@ func (c Condition) Walk(vis func(v Node)) {
 func (l Link) String() string {
 	links := make([]string, len(l.Entities))
 	for i, e := range l.Entities {
-		links[i] = fmt.Sprintf("(%s ON %s)", e, l.Conditions[i])
+		links[i] = fmt.Sprintf("%s, ", e)
 	}
 	return fmt.Sprintf("link(%+v)", links)
 }
 
 // Implements data.Node
 func (l Link) Walk(vis func(v Node)) {
-	for _, c := range l.Conditions {
-		c.Walk(vis)
-	}
 	for _, e := range l.Entities {
 		e.Walk(vis)
 	}


### PR DESCRIPTION
# Description

Due to the misunderstanding of the translation of OPA's AST to SQL-INNER-JOINS, the current implementation was not working with policies that had a wrong structure. Due to the fact that the order of statements inside a policy should not matter, this error was fixed by removing JOIN-Conditions.

Now the JOIN is done using the 'old-school' SQL-Join (Via WHERE-Clauses)