### PR TITLE
Implemented configuration of SQL-Datastore polling

### DIFF
--- a/examples/docker-compose/config/datastore.yml
+++ b/examples/docker-compose/config/datastore.yml
@@ -8,6 +8,10 @@ datastores:
       database: appstore
       user: You
       password: SuperSecure
+    metadata:
+      maxIdleConnections: 5
+      maxOpenConnections: 10
+      connectionMaxLifetimeSeconds: 1800
 
   pg:
     type: postgres
@@ -18,6 +22,10 @@ datastores:
       user: You
       password: SuperSecure
       sslmode: disable
+    metadata:
+      maxIdleConnections: 5
+      maxOpenConnections: 10
+      connectionMaxLifetimeSeconds: 1800
 
   mongo:
     type: mongo

--- a/examples/local/config/datastore.yml
+++ b/examples/local/config/datastore.yml
@@ -8,6 +8,10 @@ datastores:
       database: appstore
       user: You
       password: SuperSecure
+    metadata:
+      maxIdleConnections: 5
+      maxOpenConnections: 10
+      connectionMaxLifetimeSeconds: 1800
 
   pg:
     type: postgres
@@ -18,6 +22,10 @@ datastores:
       user: You
       password: SuperSecure
       sslmode: disable
+    metadata:
+      maxIdleConnections: 5
+      maxOpenConnections: 10
+      connectionMaxLifetimeSeconds: 1800
 
   mongo:
     type: mongo


### PR DESCRIPTION
# Description 

Pool-options of datastore can now be configured by setting the metadata option of each datastore connection in the datastore.yaml-file.

!! This feature affects only SQL-Datastores [PostgreSQL, MySQL] !!

An example would be:

```yaml
datastores:
  mysql:
    type: mysql
    connection:
      host: localhost
      port: 3306
      database: appstore
      user: You
      password: SuperSecure
    metadata:
      maxIdleConnections: 5
      maxOpenConnections: 10
      connectionMaxLifetimeSeconds: 1800
```