### PR TITLE
Configure service name in application insights

### DIFF
--- a/cmd/kelon/kelon.go
+++ b/cmd/kelon/kelon.go
@@ -65,6 +65,7 @@ var (
 	// Configs for telemetry
 	telemetryService            = app.Flag("telemetry-service", "Service that is used for telemetry [Prometheus, ApplicationInsights]").Envar("TELEMETRY_SERVICE").Enum("Prometheus", "prometheus", "ApplicationInsights", "applicationinsights")
 	instrumentationKey          = app.Flag("instrumentation-key", "The ApplicationInsights-InstrumentationKey that is used to connect to the API.").Envar("INSTRUMENTATION_KEY").String()
+	appInsightsServiceName      = app.Flag("application-insights-service-name", "The name which will be displayed for kelon inside application insights.").Default("Kelon").Envar("APPLICATION_INSIGHTS_SERVICE_NAME").String()
 	appInsightsMaxBatchSize     = app.Flag("application-insights-max-batch-size", "Configure how many items can be sent in one call to the data collector.").Default("8192").Envar("APPLICATION_INSIGHTS_MAX_BATCH_SIZE").Int()
 	appInsightsMaxBatchInterval = app.Flag("application-insights-max-batch-interval-seconds", "Configure the maximum delay before sending queued telemetry.").Default("2").Envar("APPLICATION_INSIGHTS_MAX_BATCH_INTERVAL_SECONDS").Int()
 
@@ -159,6 +160,7 @@ func makeTelemetryProvider() telemetry.Provider {
 		case constants.ApplicationInsightsTelemetry:
 			telemetryProvider = &telemetry.ApplicationInsights{
 				AppInsightsInstrumentationKey: *instrumentationKey,
+				ServiceName:                   *appInsightsServiceName,
 				MaxBatchSize:                  *appInsightsMaxBatchSize,
 				MaxBatchIntervalSeconds:       *appInsightsMaxBatchInterval,
 			}

--- a/pkg/telemetry/applicationinsights.go
+++ b/pkg/telemetry/applicationinsights.go
@@ -13,9 +13,10 @@ import (
 
 type ApplicationInsights struct {
 	AppInsightsInstrumentationKey string
-	client                        appinsights.TelemetryClient
+	ServiceName                   string
 	MaxBatchSize                  int
 	MaxBatchIntervalSeconds       int
+	client                        appinsights.TelemetryClient
 }
 
 func (p *ApplicationInsights) Configure() error {
@@ -28,6 +29,7 @@ func (p *ApplicationInsights) Configure() error {
 	// Configure the maximum delay before sending queued telemetry:
 	telemetryConfig.MaxBatchInterval = time.Second * time.Duration(p.MaxBatchIntervalSeconds)
 	p.client = appinsights.NewTelemetryClientFromConfig(telemetryConfig)
+	p.client.Context().Tags.Cloud().SetRole(p.ServiceName)
 	log.Infoln("Configured ApplicationInsights.")
 
 	return nil


### PR DESCRIPTION
The displayed service name is now configurable via following flag
 `--application-insights-service-name=Kelon`
or alternatively via the enVar 
`APPLICATION_INSIGHTS_SERVICE_NAME`